### PR TITLE
import used rxjs debounceTime for dropdown

### DIFF
--- a/modules/components/dropdown/tag-input-dropdown.component.ts
+++ b/modules/components/dropdown/tag-input-dropdown.component.ts
@@ -17,6 +17,7 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/first';
+import 'rxjs/add/operator/debounceTime';
 
 import { Ng2Dropdown, Ng2MenuItem } from 'ng2-material-dropdown';
 import { TagModel, TagInputDropdownOptions, OptionsProvider } from '../../core';


### PR DESCRIPTION
should be that fix: https://github.com/Gbuomprisco/ngx-chips/issues/546#issuecomment-324068390

Importing debounceTime in the using module doesn't work for me. Maybe some angular-cli magic is removing that. Anyways, if the dropdown component is usind debounceTime and you need an import, it should be the dropdown component importing it.