### PR TITLE
fix: enable the library to be AoT compiled with fullTemplateTypecheck

### DIFF
--- a/modules/components/tag-input/tag-input.template.html
+++ b/modules/components/tag-input/tag-input.template.html
@@ -21,7 +21,7 @@
 
              (onSelect)="selectItem(item)"
              (onRemove)="onRemoveRequested(item, i)"
-             (onKeyDown)="handleKeydown($event, item)"
+             (onKeyDown)="handleKeydown($event)"
              (onTagEdited)="onTagEdited.emit($event)"
              (onBlur)="onTagBlurred($event, i)"
              draggable="{{ editable }}"

--- a/modules/components/tag/tag.component.ts
+++ b/modules/components/tag/tag.component.ts
@@ -255,6 +255,41 @@ export class TagComponent {
     }
 
     /**
+     * @name disableEditMode
+     * @param $event
+     */
+    public disableEditMode($event?: KeyboardEvent): void {
+        const classList = this.element.nativeElement.classList;
+        const input = this.getContentEditableText();
+
+        this.editing = false;
+        classList.remove('tag--editing');
+
+        if (!input) {
+            this.setContentEditableText(this.model);
+            return;
+        }
+
+        this.storeNewValue(input);
+        this.cdRef.detectChanges();
+
+        if ($event) {
+            $event.preventDefault();
+        }
+    }
+
+    /**
+     * @name isDeleteIconVisible
+     * @returns {boolean}
+     */
+    public isDeleteIconVisible(): boolean {
+        return !this.readonly &&
+            !this.disabled &&
+            this.removable &&
+            !this.editing;
+    }
+
+    /**
      * @name getContentEditableText
      * @returns {string}
      */
@@ -283,30 +318,6 @@ export class TagComponent {
         classList.add('tag--editing');
 
         this.editing = true;
-    }
-
-    /**
-     * @name disableEditMode
-     * @param $event
-     */
-    private disableEditMode($event?: KeyboardEvent): void {
-        const classList = this.element.nativeElement.classList;
-        const input = this.getContentEditableText();
-
-        this.editing = false;
-        classList.remove('tag--editing');
-
-        if (!input) {
-            this.setContentEditableText(this.model);
-            return;
-        }
-
-        this.storeNewValue(input);
-        this.cdRef.detectChanges();
-
-        if ($event) {
-            $event.preventDefault();
-        }
     }
 
     /**
@@ -345,16 +356,5 @@ export class TagComponent {
      */
     private getContentEditable(): HTMLInputElement {
         return this.element.nativeElement.querySelector('[contenteditable]');
-    }
-
-    /**
-     * @name isDeleteIconVisible
-     * @returns {boolean}
-     */
-    private isDeleteIconVisible(): boolean {
-        return !this.readonly &&
-                !this.disabled &&
-                this.removable &&
-                !this.editing;
     }
 }


### PR DESCRIPTION
Enabling the new `fullTemplateTypecheck` option in angular v5 throws the following errors when trying to use this package:
```
Error: node_modules/ngx-chips/ngx-chips.d.ts.ɵa.html(25,20): : Expected 1 arguments, but got 2.
node_modules/ngx-chips/ngx-chips.d.ts.ɵf.html(37,19): : Property 'isDeleteIconVisible' is private and only accessible within class 'TagComponent'.
node_modules/ngx-chips/ngx-chips.d.ts.ɵf.html(25,20): : Property 'disableEditMode' is private and only accessible within class 'TagComponent'.
node_modules/ngx-chips/ngx-chips.d.ts.ɵf.html(26,20): : Property 'disableEditMode' is private and only accessible within class 'TagComponent'.
```

This patch fixes those errors.