### PR TITLE
fix(showDropdownIfEmpty): observable fix

### DIFF
--- a/modules/components/dropdown/tag-input-dropdown.component.ts
+++ b/modules/components/dropdown/tag-input-dropdown.component.ts
@@ -394,6 +394,9 @@ export class TagInputDropdown {
             } else if (!this.showDropdownIfEmpty && this.isVisible) {
                 this.dropdown.hide();
             }
+            else if( !this.showDropdownIfEmpty ) {
+                this.dropdown.hide();
+            }
         };
 
         this.autocompleteObservable(text)


### PR DESCRIPTION
When an observable initially returns results, user keeps typing, then the observable returns empty result then the dropdown displays even though showDropdownIfEmpty=false and result set is empty.