### PR TITLE
fix: skip keydown event if IME is processing the key

### DIFF
--- a/modules/components/tag-input/tag-input.ts
+++ b/modules/components/tag-input/tag-input.ts
@@ -991,8 +991,10 @@ export class TagInputComponent extends TagInputAccessor implements OnInit, After
         const listener = ($event) => {
             const hasKeyCode = this.separatorKeyCodes.indexOf($event.keyCode) >= 0;
             const hasKey = this.separatorKeys.indexOf($event.key) >= 0;
+            // the keyCode of keydown event is 229 when IME is processing the key event.
+            const isIMEProcessing = $event.keyCode === 229;
 
-            if (hasKeyCode || hasKey) {
+            if (hasKeyCode || (hasKey && !isIMEProcessing)) {
                 $event.preventDefault();
                 this.onAddingRequested(false, this.formValue)
                     .catch(() => {});


### PR DESCRIPTION
Some developers use `separatorKeys="[' ']"` to separate tags, however, this configuration will interfere the IME workflow in an unexpected way.

Most IME will use `space` key as short-path to the first candidate. When user hits the `space` during IME sessions, the keydown event will be emitted from browser with `keyCode=229, key=" "` [[spec]]. This event will trigger tagging with `separatorKeys="[' ']"` settings. However, the user expects to finish from the IME but not triggering tags adding.

This commit will detec if `$event.keyCode` is 229 and then skip tagging when the user has set `separatorKeys` only. Most `separatorKeyCodes` configuration will not have this issue unless developers opt in to process the keyCode=229 keydown event.

For those who are not familiar with Chinese/Japanese IME, here is a [minimal test case] to show the interference I mentioned above.

![image](https://user-images.githubusercontent.com/3607926/42148407-ad6b66f0-7e04-11e8-9fdb-4d3888facbd8.png)


[spec]: https://www.w3.org/TR/uievents/#determine-keydown-keyup-keyCode
[minimal test case]: https://stackblitz.com/edit/angular-ltocrd?file=src%2Fapp%2Fapp.component.html