### PR TITLE
fix the path of TagInputDropDown Component

### DIFF
--- a/modules/core/accessor.ts
+++ b/modules/core/accessor.ts
@@ -1,7 +1,7 @@
-import {ControlValueAccessor} from '@angular/forms';
-import {Input} from '@angular/core';
-import {OptionsProvider} from './providers/options-provider';
-import {TagInputDropdown} from '../../modules/components/dropdown/tag-input-dropdown.component';
+import { ControlValueAccessor } from '@angular/forms';
+import { Input } from '@angular/core';
+import { OptionsProvider } from './providers/options-provider';
+import { TagInputDropdown } from '../components/dropdown/tag-input-dropdown.component';
 
 export class TagModelClass {
     [key: string]: any;
@@ -32,7 +32,7 @@ export class TagInputAccessor implements ControlValueAccessor {
 
     public get items(): TagModel[] {
         return this._items;
-    };
+    }
 
     public set items(items: TagModel[]) {
         this._items = items;


### PR DESCRIPTION
In version 1.9.6 there is a build problem when you use the package in any project

>  "ERROR in node_modules/ngx-chips/core/accessor.d.ts(2,34): error TS2307: Cannot find module '../../modules/components/dropdown/tag-input-dropdown.component'."

This change in the TagInputDropdown path should fix the build problem, i tried it locally and it works.