### PR TITLE
Add copyable property

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ If set to `false`, it will not be possible to remove tags (defaults to `true`)
 
 If set to `true`, it will be possible to edit the display value of the tags (defaults to `false`)
 
+**`copyable`** - [**`?boolean`**]
+
+If set to `true`, it will be possible to copy the currently selected and focused tag to the clipboard, through a `copy` event (defaults to `false`)
+
 
 **`allowDupes`** - [**`?boolean`**]
 

--- a/modules/components/tag/tag.component.ts
+++ b/modules/components/tag/tag.component.ts
@@ -85,6 +85,12 @@ export class TagComponent {
     public disabled = false;
 
     /**
+     * @name disabled
+     */
+    @Input()
+    public copyable = false;
+
+    /**
      * @name canAddTag
      */
     @Input()
@@ -262,6 +268,14 @@ export class TagComponent {
      */
     public get isRippleVisible(): boolean {
         return !this.readonly && !this.editing && isChrome && this.hasRipple;
+    }
+
+    /**
+     * @desc returns whether the tag is the document's active element
+     * @name isFocused
+     */
+    public isFocused(): boolean {
+        return document.activeElement == this.element.nativeElement;
     }
 
     /**

--- a/modules/defaults.ts
+++ b/modules/defaults.ts
@@ -27,6 +27,7 @@ export interface TagInputOptions {
     blinkIfDupe: boolean;
     removable: boolean;
     editable: boolean;
+    copyable: boolean;
     allowDupes: boolean;
     modelAsStrings: boolean;
     trimTags: boolean;
@@ -82,6 +83,7 @@ export const defaults = {
         blinkIfDupe: true,
         removable: true,
         editable: false,
+        copyable: false,
         allowDupes: false,
         modelAsStrings: false,
         trimTags: true,


### PR DESCRIPTION
Hi All.

We had a requirement on our project to have the user copy the selected tag's display value.
Given that the tag may not be in the editable state, a copy event was not triggered on the selected tag.

The solution we chose was to add the copy listener to the `document` and handle the event only if the tag is both selected and focused at that moment.
Also added the onDestroy interface to remove the added event from the `document`

We added a **copyable** flag to enable this functionality, and updated the README accordingly

Lastly we had a hard time trying to add tests for this as we'd need access to the Clipboard and trigger a copy event at the `document` level.

Let me know what you think.