### PR TITLE
casing in ngAfterViewInit #879

### DIFF
--- a/modules/components/dropdown/tag-input-dropdown.component.ts
+++ b/modules/components/dropdown/tag-input-dropdown.component.ts
@@ -8,6 +8,7 @@ import {
     QueryList,
     TemplateRef,
     ViewChild,
+    AfterViewInit,
 } from '@angular/core';
 
 // rx
@@ -24,7 +25,8 @@ import { TagInputComponent } from '../tag-input/tag-input';
     selector: 'tag-input-dropdown',
     templateUrl: './tag-input-dropdown.template.html'
 })
-export class TagInputDropdown {
+export class TagInputDropdown implements AfterViewInit {
+
     /**
      * @name dropdown
      */
@@ -155,7 +157,7 @@ export class TagInputDropdown {
     /**
      * @name ngAfterviewInit
      */
-    public ngAfterviewInit(): void {
+    ngAfterViewInit(): void {
         this.onItemClicked().subscribe((item: Ng2MenuItem) => {
             this.requestAdding(item);
         });

--- a/modules/components/tag-input/tag-input.spec.ts
+++ b/modules/components/tag-input/tag-input.spec.ts
@@ -481,7 +481,7 @@ describe('TagInputComponent', () => {
             const component = getComponent(fixture);
 
             expect(component.dropdown).toBeDefined();
-            component.dropdown.ngAfterviewInit();
+            component.dropdown.ngAfterViewInit();
             // press 'i'
             component.setInputValue('i');
             component.dropdown.show();


### PR DESCRIPTION
I wrote ngAfterviewInit instead of ngAfterViewInit. this would fix #879. 
What I don't understand is why the first item in the demo "Tags accepting only items from an autocomplet" isn't added.
