### PR TITLE
Fixes to async validation

### DIFF
--- a/modules/components/tag-input-form/tag-input-form.component.ts
+++ b/modules/components/tag-input-form/tag-input-form.component.ts
@@ -197,10 +197,9 @@ export class TagInputForm implements OnInit, OnChanges {
         this.inputText = this.value.value;
         if ($event.key === 'Enter') {
             this.submit($event);
-
-            this.inputText = '';
+        } else {
+          return this.onKeydown.emit($event);
         }
-        return this.onKeydown.emit($event);
     }
 
     /**
@@ -217,8 +216,6 @@ export class TagInputForm implements OnInit, OnChanges {
      */
     public submit($event: any): void {
         $event.preventDefault();
-        if (this.form.valid) {
-            this.onSubmit.emit($event);
-        }
+        this.onSubmit.emit($event);
     }
 }

--- a/modules/components/tag-input/tag-input.ts
+++ b/modules/components/tag-input/tag-input.ts
@@ -976,9 +976,10 @@ export class TagInputComponent extends TagInputAccessor implements OnInit, After
                     .subscribe((statusUpdate) => {
                         if (statusUpdate === 'VALID' && isTagValid) {
                             appendItem();
-                            resolve();
+                            return reset();
                         } else {
-                            onValidationError();
+                            reset();
+                            return onValidationError();
                         }
                     });
             }
@@ -1029,8 +1030,6 @@ export class TagInputComponent extends TagInputAccessor implements OnInit, After
      */
     private setUpInputKeydownListeners(): void {
         this.inputForm.onKeydown.subscribe(event => {
-            this.fireEvents('keydown', event);
-
             if (event.key === 'Backspace' && this.formValue.trim() === '') {
                 event.preventDefault();
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-chips",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Async validation is broken in current branch. Keypress events are double firing causing multiple adds and the user is unable to add an async validated tag with the 'Enter' key. This commit addresses those issues.