### PR TITLE
fix(tag-input): make removeItem method public

### DIFF
--- a/modules/components/tag-input/tag-input.ts
+++ b/modules/components/tag-input/tag-input.ts
@@ -880,7 +880,7 @@ export class TagInputComponent extends TagInputAccessor implements OnInit, After
      * @param tag {TagModel}
      * @param index {number}
      */
-    private removeItem(tag: TagModel, index: number): void {
+    public removeItem(tag: TagModel, index: number): void {
         this.items = this.getItemsWithout(index);
 
         // if the removed tag was selected, set it as undefined


### PR DESCRIPTION
Angular AOT build fails if this method is private and used in code (as it is not accessible)