### PR TITLE
Autocomplete works wrong with down arrow button. #925

### DIFF
--- a/modules/components/tag-input-form/tag-input-form.component.ts
+++ b/modules/components/tag-input-form/tag-input-form.component.ts
@@ -194,6 +194,10 @@ export class TagInputForm implements OnInit, OnChanges {
      * @param $event
      */
     public onKeyDown($event) {
+        if ($event.key === 'ArrowDown') {
+          return;
+        }
+
         this.inputText = this.value.value;
         if ($event.key === 'Enter') {
             this.submit($event);


### PR DESCRIPTION
This fixes #887 #826 and #925 as it ignore down arrow when navigating to first result with down arrow from keyboard.