### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,14 +50,14 @@
     "zone.js": "~0.10.3"
   },
   "dependencies": {
-    "ng2-material-dropdown": "0.11.0"
+    "ng2-material-dropdown": ">=0.11.0"
   },
   "peerDependencies": {
-    "@angular/animations": "^10.1.5",
-    "@angular/common": "^10.1.5",
-    "@angular/core": "^10.1.5",
-    "@angular/forms": "^10.1.5",
-    "@angular/compiler": "^10.1.5"
+    "@angular/animations": ">=10.1.5",
+    "@angular/common": ">=10.1.5",
+    "@angular/core": ">=10.1.5",
+    "@angular/forms": ">=10.1.5",
+    "@angular/compiler": ">=10.1.5"
   },
   "keywords": [
     "angular tag input",

--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "ng2-material-dropdown": "0.11.0"
   },
   "peerDependencies": {
-    "@angular/animations": "~10.1.5",
-    "@angular/common": "~10.1.5",
-    "@angular/core": "~10.1.5",
-    "@angular/forms": "~10.1.5",
-    "@angular/compiler": "~10.1.5"
+    "@angular/animations": "^10.1.5",
+    "@angular/common": "^10.1.5",
+    "@angular/core": "^10.1.5",
+    "@angular/forms": "^10.1.5",
+    "@angular/compiler": "^10.1.5"
   },
   "keywords": [
     "angular tag input",


### PR DESCRIPTION
Peer Dependency bug fix in NPM 7
This will allow projects on **ERESOLVE overriding peer dependency** instead of failing. I propose you remove the PEER Dependency to future proof it and depend on user angular versions
Although we still get this warning, the project npm install succeeds 
```
npm WARN ERESOLVE overriding peer dependency
npm WARN Found: @angular/animations@10.2.2
npm WARN node_modules/@angular/animations
npm WARN   @angular/animations@"10.2.2" from the root project
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer @angular/animations@"^8.0.0" from ng2-material-dropdown@0.11.0
npm WARN node_modules/ng2-material-dropdown
npm WARN   ng2-material-dropdown@"0.11.0" from ngx-chips@2.2.1
npm WARN   node_modules/ngx-chips
npm WARN ERESOLVE overriding peer dependency
npm WARN Found: @angular/common@10.2.2
npm WARN node_modules/@angular/common
npm WARN   @angular/common@"10.2.2" from the root project
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer @angular/common@"^8.0.0" from ng2-material-dropdown@0.11.0
npm WARN node_modules/ng2-material-dropdown
npm WARN   ng2-material-dropdown@"0.11.0" from ngx-chips@2.2.1
npm WARN   node_modules/ngx-chips
npm WARN ERESOLVE overriding peer dependency
npm WARN Found: @angular/core@10.2.2
npm WARN node_modules/@angular/core
npm WARN   @angular/core@"10.2.2" from the root project
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer @angular/core@"^8.0.0" from ng2-material-dropdown@0.11.0
npm WARN node_modules/ng2-material-dropdown
npm WARN   ng2-material-dropdown@"0.11.0" from ngx-chips@2.2.1
npm WARN   node_modules/ngx-chips
```